### PR TITLE
Allow for "noexcept nogil" after function/method declarations

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1003,7 +1003,7 @@ export namespace Localizer {
         export const expectedNamespace = () => getRawString('Diagnostic.expectedNamespace');
         export const expectedFileName = () => getRawString('Diagnostic.expectedFileName');
         export const expectedWith = () => getRawString('Diagnostic.expectedWith');
-        export const expectedNoGil = () => getRawString('Diagnostic.expectedNoGil');
+        export const noexceptWithoutNogil = () => getRawString('Diagnostic.noexceptWithoutNogil');
         export const noexceptWithGil = () => getRawString('Diagnostic.noexceptWithGil');
         export const expectedCastClose = () => getRawString('Diagnostic.expectedCastClose');
         export const deprecatedPropertyCython = () => getRawString('Diagnostic.deprecatedPropertyCython');

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1004,7 +1004,6 @@ export namespace Localizer {
         export const expectedFileName = () => getRawString('Diagnostic.expectedFileName');
         export const expectedWith = () => getRawString('Diagnostic.expectedWith');
         export const noexceptWithoutNogil = () => getRawString('Diagnostic.noexceptWithoutNogil');
-        export const noexceptWithGil = () => getRawString('Diagnostic.noexceptWithGil');
         export const expectedCastClose = () => getRawString('Diagnostic.expectedCastClose');
         export const deprecatedPropertyCython = () => getRawString('Diagnostic.deprecatedPropertyCython');
         export const deprecatedForFromLoop = () => getRawString('Diagnostic.deprecatedForFromLoop');

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1003,6 +1003,7 @@ export namespace Localizer {
         export const expectedNamespace = () => getRawString('Diagnostic.expectedNamespace');
         export const expectedFileName = () => getRawString('Diagnostic.expectedFileName');
         export const expectedWith = () => getRawString('Diagnostic.expectedWith');
+        export const expectedNoGil = () => getRawString('Diagnostic.expectedNoGil');
         export const noexceptWithoutNogil = () => getRawString('Diagnostic.noexceptWithoutNogil');
         export const expectedCastClose = () => getRawString('Diagnostic.expectedCastClose');
         export const deprecatedPropertyCython = () => getRawString('Diagnostic.deprecatedPropertyCython');

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1004,6 +1004,7 @@ export namespace Localizer {
         export const expectedFileName = () => getRawString('Diagnostic.expectedFileName');
         export const expectedWith = () => getRawString('Diagnostic.expectedWith');
         export const expectedNoGil = () => getRawString('Diagnostic.expectedNoGil');
+        export const noexceptWithGil = () => getRawString('Diagnostic.noexceptWithGil');
         export const expectedCastClose = () => getRawString('Diagnostic.expectedCastClose');
         export const deprecatedPropertyCython = () => getRawString('Diagnostic.deprecatedPropertyCython');
         export const deprecatedForFromLoop = () => getRawString('Diagnostic.deprecatedForFromLoop');

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -529,6 +529,7 @@
         "expectedFileName": "Expected file name after \"include\"",
         "expectedWith": "Expected \"with\"",
         "expectedNoGil": "Expected \"nogil\"",
+        "noexceptWithGil": "Expected \"nogil\" following \"noexcept\"",
         "expectedCastClose": "Expected cast close: \">\"",
         "deprecatedPropertyCython": "Property declaration is deprecated. Use \"@property\" decorator",
         "deprecatedForFromLoop": "\"For From\" loop is deprecated. Use normal Python for loop",

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -529,7 +529,7 @@
         "expectedFileName": "Expected file name after \"include\"",
         "expectedWith": "Expected \"with\"",
         "expectedNoGil": "Expected \"nogil\"",
-        "noexceptWithGil": "Expected \"nogil\" following \"noexcept\"",
+        "noexceptWithoutNogil": "Expected \"nogil\" following \"noexcept\"",
         "expectedCastClose": "Expected cast close: \">\"",
         "deprecatedPropertyCython": "Property declaration is deprecated. Use \"@property\" decorator",
         "deprecatedForFromLoop": "\"For From\" loop is deprecated. Use normal Python for loop",

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -7124,8 +7124,11 @@ export class Parser {
             return;
         }
         let withToken: KeywordToken | undefined = undefined;
+        let nogilToken: KeywordToken | undefined = undefined;
         if (this._peekKeywordType() === KeywordType.With) {
             withToken = this._getNextToken() as KeywordToken;
+        } else if (this._peekKeywordType() == KeywordType.Noexcept){
+            nogilToken = this._getNextToken() as KeywordToken;
         }
         if (withToken && keywordType !== KeywordType.Cdef && keywordType !== KeywordType.Ctypedef) {
             this._addError(Localizer.Diagnostic.expectedColon(), withToken);
@@ -7136,7 +7139,11 @@ export class Parser {
             if (keywordType !== KeywordType.Cdef && keywordType !== KeywordType.Ctypedef) {
                 this._addError(Localizer.Diagnostic.invalidTrailingGilFunction(), gilToken);
             } else {
-                if (!withToken && gilToken.keywordType === KeywordType.Gil) {
+                // Check 'noexcept' first since user may try to use it with Gil
+                if (nogilToken && gilToken.keywordType !== KeywordType.Nogil) {
+                    // "noexcept" must be followed by nothing or "nogil"
+                    this._addError(Localizer.Diagnostic.noexceptWithoutNogil(), nogilToken);
+                } else if (!withToken && gilToken.keywordType === KeywordType.Gil) {
                     // "gil" must be preceeded by "with"
                     this._addError(Localizer.Diagnostic.expectedWith(), gilToken);
                 } else if (withToken && gilToken.keywordType === KeywordType.Nogil) {


### PR DESCRIPTION
Modified parser to not throw errors for functions of the type:

```python
cdef double f(double x) noexcept nogil:
    return x * x
```

The "noexcept nogil" is allowed (and [often used](https://github.com/scipy/scipy/blob/1b6f678a97a554ab4fec4d51bbd961ca4c63b4c8/scipy/special/_lambertw.pxd)) format since Cython 3.0.0+.

This is related to vs-code-cython [issue #20](https://github.com/ktnrg45/vs-code-cython/issues/20) and [PR #21](https://github.com/ktnrg45/vs-code-cython/pull/21).

- New error was added that is thrown if "noexcept" is followed by anything other than nothing or "nogil".
- _No new tests have been added!_
